### PR TITLE
Fix and test case for Ionization bug

### DIFF
--- a/src/core/Ionization.cpp
+++ b/src/core/Ionization.cpp
@@ -44,9 +44,14 @@ namespace RADAGAST
         const Array& Iv = meanIntensity.valuev();
         const Array& nuv = meanIntensity.frequencyv();
 
-        // stop when we go below threshold
-        Array integrandv(nuv.size());
+        // start at largest frequency, and stop when we go below threshold
         int i = nuv.size() - 1;
+
+        // when ionizing radiation is not included in wavelength grid, return early
+        if (nuv[i] < THRESHOLD)
+            return 0.;
+
+        Array integrandv(nuv.size());
         while (i >= 0 && nuv[i] > THRESHOLD)
         {
             // Start from I_nu -> erg s-1 cm-2 hz-1 sr-1. Then, 4pi I_nu / hnu = s-1 cm-2 hz-1.

--- a/src/core/test_Ionization.cpp
+++ b/src/core/test_Ionization.cpp
@@ -1,0 +1,39 @@
+#include "DoctestUtils.hpp"
+#include "Ionization.hpp"
+#include "RadiationFieldTools.hpp"
+#include "Spectrum.hpp"
+#include "Testing.hpp"
+#include "Ionization.hpp"
+
+using namespace RADAGAST;
+
+TEST_CASE("Ionization threshold not in grid")
+{
+    // There was a bug where the code segfaulted when a wavelength grid was chosen for which the
+    // H ionization threshold frequency was not in its bounds.
+
+    Array frequencyv;
+    double nu0 = Ionization::THRESHOLD;
+    bool shouldBeZero;
+
+    // two subcases we want to test:
+    SUBCASE("max frequency < threshold")
+    {
+        frequencyv = Testing::generateGeometricGridv(200, nu0 / 4, nu0 / 1.1);
+        shouldBeZero = true;
+    }
+    SUBCASE("threshold < min frequency")
+    {
+        frequencyv = Testing::generateGeometricGridv(200, nu0 * 1.1, nu0 * 2);
+        shouldBeZero = false;
+    }
+
+    const Array& meanIntensityv = RadiationFieldTools::generateSpecificIntensityv(frequencyv, 10000, 100);
+    Spectrum meanIntensity(frequencyv, meanIntensityv);
+    double photoRate = Ionization::photoRateCoeff(meanIntensity);
+
+    if (shouldBeZero)
+        CHECK(photoRate == 0.);
+    else
+        CHECK(photoRate > 0.);
+}


### PR DESCRIPTION
Added a check which returns a photoionization rate of 0. if the maximum frequency falls below the ionization threshold.