### PR TITLE
Rework LineProfile and its tests to support T=0

### DIFF
--- a/src/core/LevelSolution.cpp
+++ b/src/core/LevelSolution.cpp
@@ -65,7 +65,6 @@ namespace RADAGAST
         _levelCoefficients->forActiveLinesDo([&](size_t upper, size_t lower) {
             double factor = _levelCoefficients->lineOpacityFactor(upper, lower, _nv(upper), _nv(lower));
             LineProfile lp = _levelCoefficients->lineProfile(upper, lower, _t, _cvv);
-            // lp.addToSpectrum(oFrequencyv, total, factor);
             lp.addToBinned(oFrequencyv, total, factor);
         });
         return total;

--- a/src/core/LineProfile.hpp
+++ b/src/core/LineProfile.hpp
@@ -22,12 +22,6 @@ namespace RADAGAST
             points */
         void addToBinned(const Array& frequencyv, Array& binnedSpectrumv, double factor) const;
 
-        /** Adds the contribution of a single line to the given spectrum. This way we can stop
-            evaluating the voigt function for the line once the contribution to the total spectrum
-            drops below a chosen threshold. 'factor' is the factor by which the line profile should
-            be multiplied before its values are added to the spectrum. */
-        void addToSpectrum(const Array& frequencyv, Array& spectrumv, double factor) const;
-
         /** Integrate the product of the line profile and the given spectrum in an efficient way. A
             recommended set of frequency points for the line (determined by this class) is combined
             with the frequency points that discretize the given spectrum.
@@ -48,6 +42,8 @@ namespace RADAGAST
         double _center, _sigma_gauss, _halfWidth_lorentz;
         double _one_sqrt2sigma;
         double _a;
+        // workaround which switches to purely Lorentzian profile when T=0
+        bool _lorentzMode{false};
     };
 }
 #endif  // CORE_LINEPROFILE_H */


### PR DESCRIPTION
This should solve #5 and adds a test case for it, which will fail (due to nan) if _lorentzMode is forced to false.

Also, I removed an obsolete function declaration, addToSpectrum (was superseded by addToBinned a long time ago).