### PR TITLE
Support H2 self-shielding factor set by client code

### DIFF
--- a/src/core/GasInterface.cpp
+++ b/src/core/GasInterface.cpp
@@ -27,9 +27,9 @@ namespace RADAGAST
     const std::valarray<double>& GasInterface::eFrequencyv() const { return _pimpl->eFrequencyv(); }
 
     void GasInterface::updateGasState(GasState& gs, double n, const std::valarray<double>& meanIntensityv,
-                                      GrainInterface& gri, GasDiagnostics* gd) const
+                                      double fshield, GrainInterface& gri, GasDiagnostics* gd) const
     {
-        _pimpl->updateGasState(gs, n, meanIntensityv, gri, gd);
+        _pimpl->updateGasState(gs, n, meanIntensityv, fshield, gri, gd);
     }
 
     std::valarray<double> GasInterface::serialize(const GasState& gs) const
@@ -87,16 +87,16 @@ namespace RADAGAST
 
     int GasInterface::index(const std::string& name) const { return _pimpl->index(name); }
 
-    GasSolution GasInterface::solveTemperature(double n, const Spectrum& meanIntensity,
+    GasSolution GasInterface::solveTemperature(double n, const Spectrum& meanIntensity, double fshield,
                                                RADAGAST::GrainInterface& gri) const
     {
-        return _pimpl->solveTemperature(n, meanIntensity, gri);
+        return _pimpl->solveTemperature(n, meanIntensity, fshield, gri);
     }
 
-    GasSolution GasInterface::solveDensities(double n, double T, const Spectrum& meanIntensity,
+    GasSolution GasInterface::solveDensities(double n, double T, const Spectrum& meanIntensity, double fshield,
                                              RADAGAST::GrainInterface& gri, double h2FormationOverride) const
     {
-        return _pimpl->solveDensities(n, T, meanIntensity, gri, h2FormationOverride);
+        return _pimpl->solveDensities(n, T, meanIntensity, fshield, gri, h2FormationOverride);
     }
 
     double GasInterface::solveDensities(GasSolution& s, double n, double T, const Spectrum& meanIntensity,

--- a/src/core/GasInterface.hpp
+++ b/src/core/GasInterface.hpp
@@ -92,12 +92,20 @@ namespace RADAGAST
             objects. The absorption efficiency of the grains currently needs to be tabulated for
             the same frequencies contained in iFrequencyv.
 
+            Since H2 self-shielding is a non-local effect, it cannot be taken into account by
+            RADAGAST (except with extremely high spectral resolution). The fshield argument
+            provides a way to let the client provide an appropriate self-shielding factor
+            (between 0 and 1), typically derived from its own radiative transfer calculations or
+            approximation for NH2. If this factor is provided, the 'naive' free-space
+            dissociation rate will be multiplied by it. (D = f * average FUV * integrated
+            sigma).
+
             The last argument is an optional pointer to a GasDiagnostics object. If provided, the
             object will be filled with various diagnostic data (slow!). I'm not sure if I'm going
             to keep this functionality, now that the functions for working with @c GasSolution
             exist. */
-        void updateGasState(GasState&, double n, const std::valarray<double>& meanIntensityv, GrainInterface& gri,
-                            GasDiagnostics* gd = nullptr) const;
+        void updateGasState(GasState&, double n, const std::valarray<double>& meanIntensityv, double fshield,
+                            GrainInterface& gri, GasDiagnostics* gd = nullptr) const;
 
         /** Serialize GasState into array of doubles, which makes it easier for the client code
             to implement storage and e.g. MPI communication. Not implemented in GasState,
@@ -155,12 +163,13 @@ namespace RADAGAST
 
         /** Find the equilibrium temperature, by repeatedly solving the densities and evaluating th
             heating and cooling. @c updateGasState works via this function under the hood. */
-        GasSolution solveTemperature(double n, const Spectrum& meanIntensity, RADAGAST::GrainInterface&) const;
+        GasSolution solveTemperature(double n, const Spectrum& meanIntensity, double fshield,
+                                     RADAGAST::GrainInterface&) const;
 
         /** Find the equilibrium densities for a fixed temperature (heating/cooling will be out of
             equilibrium). */
-        GasSolution solveDensities(double n, double T, const Spectrum& meanIntensity, RADAGAST::GrainInterface&,
-                                   double h2FormationOverride = -1) const;
+        GasSolution solveDensities(double n, double T, const Spectrum& meanIntensity, double fshield,
+                                   RADAGAST::GrainInterface&, double h2FormationOverride = -1) const;
 
         /** Recalculate the densities for an existing GasSolution object. If startFromCurrent is
             true, the current contents of the GasSolution are potentially used as an initial guess

--- a/src/core/GasInterfaceImpl.cpp
+++ b/src/core/GasInterfaceImpl.cpp
@@ -443,7 +443,7 @@ namespace RADAGAST
         // Reference: Effective Modern C++. 42 SPECIFIC WAYS TO IMPROVE YOUR USE OF C++11 AND
         // C++14. Scott Meyers.
         std::unique_ptr<HModel> hm = _manager.makeHModel(&meanIntensity);
-        std::unique_ptr<H2Model> h2m = _manager.makeH2Model(&meanIntensity);
+        std::unique_ptr<H2Model> h2m = _manager.makeH2Model(&meanIntensity, fshield);
         GasSolution s(gri, &meanIntensity, fshield, &_chemistry.speciesIndex(), move(hm), move(h2m), &_freeBound,
                       &_freeFree);
         return s;

--- a/src/core/GasInterfaceImpl.cpp
+++ b/src/core/GasInterfaceImpl.cpp
@@ -48,12 +48,11 @@ namespace RADAGAST
             _h2crossv[i] = 3.33 * Ionization::crossSection(oFrequencyv[i]);
     }
 
-    void GasInterfaceImpl::updateGasState(RADAGAST::GasState& gs, double n,
-                                          const std::valarray<double>& meanIntensityv,
-                                          RADAGAST::GrainInterface& grainInfo, GasDiagnostics* gd) const
+    void GasInterfaceImpl::updateGasState(RADAGAST::GasState& gs, double n, const std::valarray<double>& meanIntensityv,
+                                          double fshield, RADAGAST::GrainInterface& grainInfo, GasDiagnostics* gd) const
     {
         Spectrum meanIntensity(_iFrequencyv, meanIntensityv);
-        GasSolution s = solveTemperature(n, meanIntensity, grainInfo);
+        GasSolution s = solveTemperature(n, meanIntensity, fshield, grainInfo);
         s.setGasState(gs);
         if (gd) s.fillDiagnostics(gd);
     }
@@ -108,7 +107,7 @@ namespace RADAGAST
 
         // calculate the gas solution, without iteration since we already provide the correct t
         // and nv
-        auto s = makeGasSolution(meanIntensity, &gri);
+        auto s = makeGasSolution(meanIntensity, 1., &gri);
         s.setT(gs._t);
         s.setSpeciesNv(sv.speciesNv());
         s.solveGrains();
@@ -137,7 +136,7 @@ namespace RADAGAST
 
         // calculate the gas solution, without iteration since we already provide the correct t
         // and nv
-        auto s = makeGasSolution(meanIntensity, &gri);
+        auto s = makeGasSolution(meanIntensity, 1., &gri);
         s.setT(gs._t);
         s.setSpeciesNv(sv.speciesNv());
 
@@ -197,10 +196,10 @@ namespace RADAGAST
         }
     }  // namespace
 
-    GasSolution GasInterfaceImpl::solveTemperature(double n, const Spectrum& meanIntensity,
+    GasSolution GasInterfaceImpl::solveTemperature(double n, const Spectrum& meanIntensity, double fshield,
                                                    RADAGAST::GrainInterface& gri) const
     {
-        GasSolution s = makeGasSolution(meanIntensity, &gri);
+        GasSolution s = makeGasSolution(meanIntensity, fshield, &gri);
         if (n <= 0)
         {
             solveDensities(s, 0, 0, meanIntensity);
@@ -291,10 +290,10 @@ namespace RADAGAST
         return s;
     }
 
-    GasSolution GasInterfaceImpl::solveDensities(double n, double T, const Spectrum& meanIntensity,
+    GasSolution GasInterfaceImpl::solveDensities(double n, double T, const Spectrum& meanIntensity, double fshield,
                                                  RADAGAST::GrainInterface& gri, double h2FormationOverride) const
     {
-        GasSolution s = makeGasSolution(meanIntensity, &gri);
+        GasSolution s = makeGasSolution(meanIntensity, fshield, &gri);
         solveDensities(s, n, T, meanIntensity, false, h2FormationOverride);
         return s;
     }
@@ -420,7 +419,7 @@ namespace RADAGAST
         return previousHeating - previousCooling;
     }
 
-    GasSolution GasInterfaceImpl::makeGasSolution(const Spectrum& meanIntensity,
+    GasSolution GasInterfaceImpl::makeGasSolution(const Spectrum& meanIntensity, double fshield,
                                                   const RADAGAST::GrainInterface* gri) const
     {
         // Since I keep forgetting why it is good to make a factory function return unique
@@ -445,7 +444,8 @@ namespace RADAGAST
         // C++14. Scott Meyers.
         std::unique_ptr<HModel> hm = _manager.makeHModel(&meanIntensity);
         std::unique_ptr<H2Model> h2m = _manager.makeH2Model(&meanIntensity);
-        GasSolution s(gri, &meanIntensity, &_chemistry.speciesIndex(), move(hm), move(h2m), &_freeBound, &_freeFree);
+        GasSolution s(gri, &meanIntensity, fshield, &_chemistry.speciesIndex(), move(hm), move(h2m), &_freeBound,
+                      &_freeFree);
         return s;
     }
 

--- a/src/core/GasInterfaceImpl.hpp
+++ b/src/core/GasInterfaceImpl.hpp
@@ -50,8 +50,8 @@ namespace RADAGAST
         const std::valarray<double>& oFrequencyv() const { return _oFrequencyv; }
         const std::valarray<double>& eFrequencyv() const { return _eFrequencyv; }
 
-        void updateGasState(RADAGAST::GasState&, double n, const std::valarray<double>& meanIntensityv,
-                            RADAGAST::GrainInterface& gri, GasDiagnostics* gd = nullptr) const;
+        void updateGasState(RADAGAST::GasState&, double n, const std::valarray<double>& meanIntensityv, double fshield,
+                            RADAGAST::GrainInterface& gri, GasDiagnostics* gd) const;
 
         Array emissivityBasic(const RADAGAST::GasState& gs, bool SI = false) const;
         Array opacityBasic(const RADAGAST::GasState& gs, bool SI = false) const;
@@ -63,9 +63,10 @@ namespace RADAGAST
         std::string quickInfo(const RADAGAST::GasState& gs, const std::valarray<double>& meanIntensity) const;
         int index(const std::string& name) const;
 
-        GasSolution solveTemperature(double n, const Spectrum& meanIntensity, RADAGAST::GrainInterface&) const;
-        GasSolution solveDensities(double n, double T, const Spectrum& meanIntensity, RADAGAST::GrainInterface&,
-                                   double h2FormationOverride = -1) const;
+        GasSolution solveTemperature(double n, const Spectrum& meanIntensity, double fshield,
+                                     RADAGAST::GrainInterface&) const;
+        GasSolution solveDensities(double n, double T, const Spectrum& meanIntensity, double fshield,
+                                   RADAGAST::GrainInterface&, double h2FormationOverride = -1) const;
         double solveDensities(GasSolution&, double n, double T, const Spectrum& meanIntensity,
                               bool startFromCurrent = false, double h2FormationOverride = -1) const;
         GasSolution solveDensitiesNoH2(double n, double T, const Spectrum& meanIntensity,
@@ -74,7 +75,8 @@ namespace RADAGAST
     private:
         /** Construct a new GasSolution model, passing all the necessary (references to) objects.
             The SpeciesModelManager is used to create the HModel and H2Model. */
-        GasSolution makeGasSolution(const Spectrum& meanIntensity, const RADAGAST::GrainInterface*) const;
+        GasSolution makeGasSolution(const Spectrum& meanIntensity, double fshield,
+                                    const RADAGAST::GrainInterface*) const;
 
         /** Create a species vector which is zero everywhere, except for e-, p+, H, and H2.
             Arguments: the total amount of H nuclei n, the ionized to total fraction (np / n), the

--- a/src/core/GasSolution.cpp
+++ b/src/core/GasSolution.cpp
@@ -96,8 +96,8 @@ namespace RADAGAST
 
         // scale these H2 quantities with the shielding factor for now. A more physically
         // motivated approach might be implemented later at a lower level, inside the H2 model
-        double h2Line = _h2Solution->netHeating() * _fshield;
-        double dissHeat = _h2Solution->dissociationHeating() * _fshield;
+        double h2Line = _h2Solution->netHeating();
+        double dissHeat = _h2Solution->dissociationHeating();
 
         double grainHeat = grainHeating();
         DEBUG("Heating contributions: Hln " << hLine << " H2ln " << h2Line << " Hphot " << hPhotoIonHeat << " H2diss "
@@ -129,7 +129,7 @@ namespace RADAGAST
         if (!gd) Error::runtime("GasDiagnostics is nullptr!");
 
         double h2form = kGrainH2FormationRateCoeff();
-        double h2dissoc = _h2Solution->dissociationRate() * _fshield;
+        double h2dissoc = _h2Solution->dissociationRate();
 
         double hphotoion = Ionization::photoRateCoeff(*_meanIntensity);
         double hcolion = Ionization::collisionalRateCoeff(_t);
@@ -149,7 +149,7 @@ namespace RADAGAST
             }
         }
         double netHline = _hSolution->netHeating();
-        double netH2line = _h2Solution->netHeating() * _fshield;
+        double netH2line = _h2Solution->netHeating();
 
         gd->setHeating("H ion", nH() * _ionHeatPerH);
         gd->setCooling("Hrec", Ionization::cooling(nH(), np(), ne(), _t));
@@ -158,7 +158,7 @@ namespace RADAGAST
 
         gd->setHeating("H2 deexc", netH2line);
         gd->setCooling("H2 exc", -netH2line);
-        gd->setHeating("H2 dissoc", kDissH2Levels());
+        gd->setHeating("H2 dissoc", _h2Solution->dissociationHeating());
         gd->setCooling("freefree", _freeFree->cooling(np() * ne(), _t));
 
         // I need this per grain size. Doing this thing for now.
@@ -177,7 +177,7 @@ namespace RADAGAST
         g.setMembers(_t, {_sv.data(), _sv.size()}, _hSolution->n2s());
     }
 
-    double GasSolution::kDissH2Levels() const { return _h2Solution->dissociationRate() * _fshield; }
+    double GasSolution::kDissH2Levels() const { return _h2Solution->dissociationRate(); }
 
     double GasSolution::kGrainH2FormationRateCoeff() const { return _kGrainH2FormationRateCoeff; }
 }

--- a/src/core/Options.hpp
+++ b/src/core/Options.hpp
@@ -14,7 +14,7 @@ namespace RADAGAST
         // PHYSICS //
         /////////////
 
-        const bool speciesmodelmanager_enableBigH2 = true;
+        const bool speciesmodelmanager_enableBigH2 = false;
 
         // Determine which levels and transition data to load/use for the electronic ground
         // state (X) and the electronically excited states (E). These can be set separately

--- a/src/core/SimpleH2.cpp
+++ b/src/core/SimpleH2.cpp
@@ -7,7 +7,7 @@
 
 namespace RADAGAST
 {
-    SimpleH2::SimpleH2(const LookupTable* lteCool, const Spectrum* meanIntensity) : _lteCool{lteCool}
+    SimpleH2::SimpleH2(const LookupTable* lteCool, const Spectrum* meanIntensity, double fshield) : _fshield{fshield}, _lteCool{lteCool}
     {
         _g = RadiationFieldTools::gHabing(*meanIntensity);
     }
@@ -19,11 +19,8 @@ namespace RADAGAST
         // double Rpump = 3.4e-10 * beta(tau) * G_0 * exp(-2.5 * Av); I assume that G_0 * exp(-2.5
         // * Av) is just the attenuated radiation field.
 
-        // We might needs some value for tau / beta to describe self-shielding. For now, use 1.
-        double beta = 1;
-
         // equation A8 and a factor 1e-1 (from the text: 10% pumps end up in dissociation)
-        double Rpump = 3.4e-10 * beta * _g;
+        double Rpump = 3.4e-10 * _fshield * _g;
         constexpr double Rdecay = 2e-7;  // s-1
 
         // Equation A13 and A14, for downward collisions --> deexcitation heating. Divide by 6
@@ -44,7 +41,7 @@ namespace RADAGAST
         _nH2g = _nH2 - _nH2s;
 
         // Equation A9, for dissociation heating
-        _gamma3 = 1.36e-23 * _nH2 * beta * _g;
+        _gamma3 = 1.36e-23 * _nH2 * _fshield * _g;
 
         // Energy of the psuedo level. See text below eq. A11 in TH85
         constexpr double Es = 2.6 * Constant::EV;

--- a/src/core/SimpleH2.hpp
+++ b/src/core/SimpleH2.hpp
@@ -16,7 +16,7 @@ namespace RADAGAST
     public:
         /** Create a new workspace for the simple H2 model. A pointer to the LTE H2 line cooling
             table needs to be given (see SpeciesModelManager). */
-        SimpleH2(const LookupTable* lteCool, const Spectrum* meanIntensity);
+        SimpleH2(const LookupTable* lteCool, const Spectrum* meanIntensity, double fshield);
 
         /** Calculate the H2 to H2* ratio, and all other quantities that depend on more than
             just the radiation field. Should be called before any of the functions below. */
@@ -33,6 +33,7 @@ namespace RADAGAST
 
         // set at construction
         double _g{0};  // radiation field in habing units
+        double _fshield{0}; // self-shielding factor provided by client code
 
         // set during solve()
         double _nH2{0};                           // total H2 density

--- a/src/core/SpeciesModelManager.cpp
+++ b/src/core/SpeciesModelManager.cpp
@@ -22,11 +22,11 @@ namespace RADAGAST
         return std::make_unique<HModel>(_hData.get(), meanIntensity);
     }
 
-    std::unique_ptr<H2Model> SpeciesModelManager::makeH2Model(const Spectrum* meanIntensity) const
+    std::unique_ptr<H2Model> SpeciesModelManager::makeH2Model(const Spectrum* meanIntensity, double fshield) const
     {
         if (Options::speciesmodelmanager_enableBigH2)
             return std::make_unique<BigH2Model>(_h2Data.get(), meanIntensity);
         else
-            return std::make_unique<SimpleH2>(&_h2LTECool, meanIntensity);
+            return std::make_unique<SimpleH2>(&_h2LTECool, meanIntensity, fshield);
     }
 }

--- a/src/core/SpeciesModelManager.hpp
+++ b/src/core/SpeciesModelManager.hpp
@@ -32,7 +32,7 @@ namespace RADAGAST
             H2 data stored here, while a SmallH2Model ideally does not need it. A pointer to the
             radiation field is requested, to allow the H2 model to precalculate some
             quantities. */
-        std::unique_ptr<H2Model> makeH2Model(const Spectrum* meanIntensityv) const;
+        std::unique_ptr<H2Model> makeH2Model(const Spectrum* meanIntensityv, double fshield) const;
 
     private:
         std::unique_ptr<HData> _hData;

--- a/src/core/Testing.cpp
+++ b/src/core/Testing.cpp
@@ -352,7 +352,7 @@ namespace RADAGAST
 
         RADAGAST::GasState gs;
         RADAGAST::GrainInterface gri{};
-        gi.updateGasState(gs, n, meanIntensityv, gri);
+        gi.updateGasState(gs, n, meanIntensityv, 1., gri);
         writeGasState(outputPath, gi, gs);
     }
 
@@ -461,7 +461,7 @@ namespace RADAGAST
         // Initial
         Array Tv = Testing::generateGeometricGridv(100, 10, 50000);
         double T0 = 10000;
-        GasSolution s = gi.solveDensities(n, T0, meanIntensity, gri);
+        GasSolution s = gi.solveDensities(n, T0, meanIntensity, 1., gri);
         GasDiagnostics gd;
         s.fillDiagnostics(&gd);
 
@@ -931,7 +931,7 @@ namespace RADAGAST
         genMRNDust(gri, nHtotal, Spectrum{frequencyv, meanIntensityv}, car);
 
         Spectrum meanIntensity(frequencyv, meanIntensityv);
-        GasSolution s = gasInterface.solveTemperature(nHtotal, meanIntensity, gri);
+        GasSolution s = gasInterface.solveTemperature(nHtotal, meanIntensity, 1., gri);
         // Fixed temperature call, for convenience when testing:
         // GasSolution s = gi_pimpl->solveDensities(nHtotal, 49.4, meanIntensity, gri);
         if (write)

--- a/src/core/test_GasInterface.cpp
+++ b/src/core/test_GasInterface.cpp
@@ -43,7 +43,7 @@ TEST_CASE("Blackbodies test")
         Spectrum meanIntensity(frequencyv, RadiationFieldTools::generateBlackbodyv(frequencyv, Tc));
         RADAGAST::GrainInterface gri;
         if (withDust) Testing::genMRNDust(gri, nHtotal, meanIntensity, true);
-        GasSolution s = gi.solveTemperature(nHtotal, meanIntensity, gri);
+        GasSolution s = gi.solveTemperature(nHtotal, meanIntensity, 1., gri);
         double T = s.t();
         CAPTURE(Tc);
         CAPTURE(T);
@@ -78,7 +78,7 @@ TEST_CASE("zero radiation field")
         SUBCASE("nonzero grains") { Testing::genMRNDust(gri, nHtotal, meanIntensity, true); }
     }
 
-    GasSolution s = gi.solveTemperature(nHtotal, meanIntensity, gri);
+    GasSolution s = gi.solveTemperature(nHtotal, meanIntensity, 1., gri);
     // no checks for now, just make sure it doesn't crash
 }
 
@@ -90,7 +90,7 @@ TEST_CASE("serialization")
     GrainInterface gri;
     GasState gs;
     auto iv = RadiationFieldTools::generateSpecificIntensityv(gi.iFrequencyv(), 1e4, 100);
-    gi.updateGasState(gs, 1000, iv, gri);
+    gi.updateGasState(gs, 1000, iv, 1., gri);
 
     auto blob = gi.serialize(gs);
     // hardcode this, to warn me later, when I change the chemistry (number of species), or the

--- a/src/mains/krome_compare.cpp
+++ b/src/mains/krome_compare.cpp
@@ -54,7 +54,7 @@ int main()
     outfile << "# T e H H2 H+ heat cool";
     for (double T = 1000; T < 100000; T *= 1.05)
     {
-        GasSolution s = gasInterface.solveDensities(n, T, meanIntensity, gri, kGrainH2);
+        GasSolution s = gasInterface.solveDensities(n, T, meanIntensity, 1., gri, kGrainH2);
         // Uncomment this to re-use the previous solution as an initial guess
         // sp = &s;
         double heat = s.heating();
@@ -70,7 +70,7 @@ int main()
     }
     for (double T = 100000; T > 10; T /= 1.05)
     {
-        GasSolution s = gasInterface.solveDensities(n, T, meanIntensity, gri, kGrainH2);
+        GasSolution s = gasInterface.solveDensities(n, T, meanIntensity, 1., gri, kGrainH2);
         // sp = &s;
         double heat = s.heating();
         double cool = s.cooling();


### PR DESCRIPTION
Current use case: SKIRT keeps track of NH2 along the photon paths, and calculates a Monte-Carlo average of the H2 photodissociation self-shielding factor (according to the approximation by Draine & Bertoldi 1996). 

This shielding factor is now an extra argument for the gas update function at the main RADAGAST interface, and is passed down to the Simple H2 model. To get the original behavior, a shielding factor of 1. can be passed.

The Big H2 model simply ignores it for now. That's why the Simple H2 model is now the default in Options.hpp.

I have done some rudimentary testing of this version coupled to my branch of SKIRT, with the same cloudy-based test case as my thesis. Cloudy was configured to use the same shielding function, and the results look like this:
![chemical_Thu_Jan__6_17:29:23_2022](https://user-images.githubusercontent.com/7421197/148461715-92b89137-adc3-4f6c-8562-877000d11850.png)
![thermal_Thu_Jan__6_17:29:23_2022](https://user-images.githubusercontent.com/7421197/148461721-b6c37584-0d43-4ff6-8cf5-e2f60658715d.png)


Will be merging this soon, as the changes look pretty clean.