### PR TITLE
Add link to drvdputt/SKIRT9/gas-dev in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 **RAD**iation and **D**ust **A**ffecting the **GA**s **ST**ate
 
 ## Description
-RADAGAST is a local (0D) gas model for use in 3D dust radiative transfer simulations. Given a
-certain radiation field and dust model, the equilibrium state for various quantities of the gas
-are calculated self-consistently. Currently, the module treats the main species consisting of H
-(H+, H and H2), and their interactions with the radiation field and the dust grains.
+RADAGAST is a local (0D) gas model for use in 3D dust radiative transfer simulations.
+Given a certain radiation field and dust model, the equilibrium state for various quantities of the gas are calculated self-consistently.
+Currently, the module treats the main species consisting of H (H+, H and H2), and their interactions with the radiation field and the dust grains.
 
 Quantities calculated self-consistently
 - Gas equilibrium temperature
@@ -27,42 +26,36 @@ From the resulting state, the emissive properties and cross section of the gas c
 - Continuum emission of H (free-bound, free-free, and two-photon)
 - Emission coefficients, opacities, and shapes for the lines of H and H2.
 
-While RADAGAST was mainly developed for use in the 3D Monte Carlo Dust Radiative Transfer code <a
-href="http://www.skirt.ugent.be">SKIRT</a>, it is designed as a stand-alone module which,
-ideally, does not depend on SKIRT in any way. It is possible to use this module in any C++ code
-where the necessary details about the radiation field and the dust can be provided, without
-having to install anything related to SKIRT.
+While RADAGAST was mainly developed for use in the 3D Monte Carlo Dust Radiative Transfer code <a href="http://www.skirt.ugent.be">SKIRT</a>, it is designed as a stand-alone module.
+It is possible to use this module in any C++ code where the necessary details about the radiation field and the dust can be provided, without having to install anything related to SKIRT.
 
-This code was developed during my PhD research, and contains many equations and data from other authors to implement the processes listed above. Consult my PhD thesis (to be published) for details, equations, and citations. Alternatively, one can build the documentation pages or read the comments for each function in the source code.
+This code was developed during my PhD research, and contains many equations and data from other authors to implement the processes listed above.
+Consult my PhD thesis (to be published) for details, equations, and citations.
+Alternatively, one can build the documentation pages or read the comments for each function in the source code.
 
 ## Third party libraries and data
-RADAGAST includes a release of the <a href="https://github.com/onqtam/doctest">doctest</a> C++
-testing framework, to power a small set of unit tests.
+RADAGAST includes a release of the <a href="https://github.com/onqtam/doctest">doctest</a> C++ testing framework, to power a small set of unit tests.
 
-It also uses <a href="https://eigen.tuxfamily.org">Eigen3</a> for storing vectors and matrices,
-and performing linear algebra, and <a href="https://www.gnu.org/software/gsl/">GSL</a> for
-solving several non-linear equations. Currently, these libraries are dependencies, but the git
-history might contain a copy.
+It also uses <a href="https://eigen.tuxfamily.org">Eigen3</a> for storing vectors and matrices, and performing linear algebra, and <a href="https://www.gnu.org/software/gsl/">GSL</a> for solving several non-linear equations.
+Currently, these libraries are dependencies, but the git history might contain a copy.
 
 ## Getting started
 First read how to [build](dox/build.md) the library.
 
 Then try running the main binary produced at `RADAGAST/../cmake_release/src/mains/main`.
-Experiment by giving a few numerical command line arguments to this program. The command
+Experiment by giving a few numerical command line arguments to this program.
+The command
 ``` main 1e5 1e4 1e3 ```
-will run an example model with a gas density of 1e5 cm-3, under the effect
-of a blackbody source located at a (fixed) distance of 1 pc with a color temperature of 1e4 K and a
-bolometric luminosity of 1e3 solar luminosities.
+will run an example model with a gas density of 1e5 cm-3, under the effect of a blackbody source located at a (fixed) distance of 1 pc with a color temperature of 1e4 K and a bolometric luminosity of 1e3 solar luminosities.
 
-When this binary works without problems, copy the library built at
-`RADAGAST/../cmake_release/src/core/libridge.a` to your preferred location (or set
-`CMAKE_INSTALL_PREFIX` and run make install). Then read the [instructions](dox/use.md) on how to
-use the API, write a simple C++ script making the calls, and try building and linking your own
-C++ script to the library.
+When this binary works without problems, copy the library built at `RADAGAST/../cmake_release/src/core/libridge.a` to your preferred location (or set `CMAKE_INSTALL_PREFIX` and run make install).
+Then read the [instructions](dox/use.md) on how to use the API, write a simple C++ script making the calls, and try building and linking your own C++ script to the library.
 
 ## Integration in SKIRT
-The integration with SKIRT is currently being reworked, to make use of the newly developed state
-change mechanisms. See [pull request](https://github.com/SKIRT/SKIRT9/pull/79).
+The integration with SKIRT is currently being reworked, to make use of the newly developed state change mechanisms.
+See [pull request](https://github.com/SKIRT/SKIRT9/pull/79).
+Current development is happening in the [gas-dev branch of SKIRT](https://github.com/drvdputt/SKIRT9/tree/gas-dev). 
+This branch should usually be up to date with the latest of RADAGAST.
 
 The reader interested in an example of integrating RADAGAST, can examine [SKIRT as used for my
 thesis](https://github.com/drvdputt/SKIRT9/releases/tag/thesis), together with the [analogously


### PR DESCRIPTION
Now that the shielding factor has been implemented, I don't see many more crazy changes happening to the main interface. 

I added a note at the end of the readme, linking to the relevant SKIRT branch. Up next, I should take a look at the examples, update them with the shielding factor argument, and also check for incompatibilities with the real code.

I will be pushing to this branch with documentation updates.