### PR TITLE
Remove -march=native

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ add_definitions(-DREPOROOT=\"${PROJECT_SOURCE_DIR}\")
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
   add_definitions(-DSILENT)
 endif()
-add_definitions(-march=native)
 
 add_subdirectory(src/core)
 add_subdirectory(src/mains)


### PR DESCRIPTION
Was needed to make compilation work on M1 mac. Also might have been a
bad idea in general.