### PR TITLE
Important new stuff for SKIRT: fSerialize/deserialize, stop nan crashes, 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ Please remove CMakeCache.txt and call cmake from another directory")
 endif("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
 
 add_definitions(-DREPOROOT=\"${PROJECT_SOURCE_DIR}\")
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-  add_definitions(-DSILENT)
-endif()
+# if(CMAKE_BUILD_TYPE STREQUAL "Release")
+add_definitions(-DSILENT)
+# endif()
 
 add_subdirectory(src/core)
 add_subdirectory(src/mains)

--- a/src/core/Error.hpp
+++ b/src/core/Error.hpp
@@ -1,7 +1,9 @@
 #ifndef CORE_ERROR_HPP
 #define CORE_ERROR_HPP
 
+#include <cmath>
 #include <iostream>
+
 namespace RADAGAST
 {
     namespace Error
@@ -30,7 +32,7 @@ namespace RADAGAST
 
         template<typename T> void sanitize(std::string name, T value)
         {
-            if (!isfinite(value)) runtime(name + " is " + std::to_string(value) + "! Clean your input.");
+            if (!std::isfinite(value)) runtime(name + " is " + std::to_string(value) + "! Clean your input.");
         }
 
         template<typename T> void equalCheck(std::string variable_names, T value1, T value2)

--- a/src/core/Error.hpp
+++ b/src/core/Error.hpp
@@ -9,6 +9,9 @@ namespace RADAGAST
         /** Prints a message to stderr and aborts. */
         static inline void runtime(std::string message);
 
+        /** Check if number is finite and throw runtime error if not */
+        template<typename T> static inline void sanitize(T value);
+
         /** Checks if the two given values are not equal, and prints a message containing the given
             name if this is the case. */
         template<typename T> void equalCheck(std::string variable_names, T value1, T value2);
@@ -23,9 +26,11 @@ namespace RADAGAST
             abort();
         }
 
-        static inline void warn(std::string message)
+        static inline void warn(std::string message) { std::cerr << "RADAGAST warning: " << message << '\n'; }
+
+        template<typename T> void sanitize(std::string name, T value)
         {
-            std::cerr << "RADAGAST warning: " << message << '\n';
+            if (!isfinite(value)) runtime(name + " is " + std::to_string(value) + "! Clean your input.");
         }
 
         template<typename T> void equalCheck(std::string variable_names, T value1, T value2)

--- a/src/core/Error.hpp
+++ b/src/core/Error.hpp
@@ -23,6 +23,11 @@ namespace RADAGAST
             abort();
         }
 
+        static inline void warn(std::string message)
+        {
+            std::cerr << "RADAGAST warning: " << message << '\n';
+        }
+
         template<typename T> void equalCheck(std::string variable_names, T value1, T value2)
         {
             if (value1 != value2)

--- a/src/core/GasInterface.hpp
+++ b/src/core/GasInterface.hpp
@@ -110,14 +110,14 @@ namespace RADAGAST
         /** Serialize GasState into array of doubles, which makes it easier for the client code
             to implement storage and e.g. MPI communication. Not implemented in GasState,
             because GasState is agnostic about the details of the model, which we might need. */
-        std::valarray<double> serialize(const GasState&) const;
+        std::valarray<double> serialize(const GasState&, bool SI = false) const;
 
         /** Write serialized data into GasState. Typical use case:
             1. run RADAGAST in parallel (MPI)
             2. store gas states as plain doubles using serialize
             3. synchronize gas state data between processes using simple MPI calls
             4. deserialize the blobs and pass the resulting GasStates to RADAGAST to access gas information */
-        void deserialize(GasState&, const std::valarray<double>& blob) const;
+        void deserialize(GasState&, const std::valarray<double>& blob, bool SI = false) const;
 
         /** Describes every element of the output of serialize, in the form of one string per
             element. The output looks like {"T", "ne", "np", "nH", "nH2", others...}. GasState

--- a/src/core/GasInterfaceImpl.cpp
+++ b/src/core/GasInterfaceImpl.cpp
@@ -1,6 +1,7 @@
 #include "GasInterfaceImpl.hpp"
 #include "Constants.hpp"
 #include "DebugMacros.hpp"
+#include "EigenAliases.hpp"
 #include "Functions.hpp"
 #include "GrainPhotoelectricCalculator.hpp"
 #include "Ionization.hpp"
@@ -364,7 +365,9 @@ namespace RADAGAST
             if (previousAbundancev.array().isNaN().any())
             {
                 std::cerr << previousAbundancev;
-                Error::runtime("Nan in chemistry solution!");
+                Error::warn("Nan in chemistry solution! Setting to zero.");
+                previousAbundancev.setZero();
+                s.setSpeciesNv(EVector::Zero(previousAbundancev.size()));
             }
 
             // GRAIN, LEVELS, AND CHEMISTRY SOLUTIONS -> CHEM RATES

--- a/src/core/GasInterfaceImpl.cpp
+++ b/src/core/GasInterfaceImpl.cpp
@@ -2,6 +2,7 @@
 #include "Constants.hpp"
 #include "DebugMacros.hpp"
 #include "EigenAliases.hpp"
+#include "Error.hpp"
 #include "Functions.hpp"
 #include "GrainPhotoelectricCalculator.hpp"
 #include "Ionization.hpp"
@@ -15,7 +16,10 @@
 #include "TwoPhoton.hpp"
 #include <gsl/gsl_errno.h>
 #include <gsl/gsl_roots.h>
+#include <cmath>
 #include <iostream>
+#include <string>
+#include <valarray>
 
 namespace RADAGAST
 {
@@ -49,9 +53,20 @@ namespace RADAGAST
             _h2crossv[i] = 3.33 * Ionization::crossSection(oFrequencyv[i]);
     }
 
+    namespace
+    {
+        void sanitizeInput(double n, const std::valarray<double>& meanIntensityv, double fshield,
+                           RADAGAST::GrainInterface& grainInfo)
+        {
+            Error::sanitize("n", n);
+            Error::sanitize("fshield", fshield);
+        }
+    }
+
     void GasInterfaceImpl::updateGasState(RADAGAST::GasState& gs, double n, const std::valarray<double>& meanIntensityv,
                                           double fshield, RADAGAST::GrainInterface& grainInfo, GasDiagnostics* gd) const
     {
+        sanitizeInput(n, meanIntensityv, fshield, grainInfo);
         Spectrum meanIntensity(_iFrequencyv, meanIntensityv);
         GasSolution s = solveTemperature(n, meanIntensity, fshield, grainInfo);
         s.setGasState(gs);

--- a/src/core/GasSolution.cpp
+++ b/src/core/GasSolution.cpp
@@ -170,6 +170,12 @@ namespace RADAGAST
         // Other things will be written to the 'user values' of gasDiagnostics, somewhere in
         // these calls
         _h2Solution->extraDiagnostics(*gd);
+
+        // write grain temperatures of one population
+        if (_grainSolutionv.size() > 0)
+        {
+            _grainSolutionv[0].extraDiagnostics(*gd, "pop0");
+        }
     }
 
     void GasSolution::setGasState(RADAGAST::GasState& g) const

--- a/src/core/GrainSolution.cpp
+++ b/src/core/GrainSolution.cpp
@@ -142,4 +142,9 @@ namespace RADAGAST
     }
 
     double GrainSolution::averageCharge(int m) const { return _chargeDistributionv[m].average(); }
+
+    void GrainSolution::extraDiagnostics(GasDiagnostics& gd, const std::string& prefix) const
+    {
+        for (int i = 0; i < _numSizes; i++) gd.setUserValue(prefix + "T" + std::to_string(i), _newTemperaturev[i]);
+    }
 }

--- a/src/core/GrainSolution.hpp
+++ b/src/core/GrainSolution.hpp
@@ -3,6 +3,7 @@
 
 #include "Array.hpp"
 #include "ChargeDistribution.hpp"
+#include "GasDiagnostics.hpp"
 #include "GrainPhotoelectricCalculator.hpp"
 #include "GrainPopulation.hpp"
 #include "Testing.hpp"
@@ -72,6 +73,11 @@ namespace RADAGAST
         /** Return the average charge for grains with size index m of this population. Assumes
             that recalculate() has already been called. */
         double averageCharge(int m) const;
+
+        /** Add some info about the grains to the diagnostics. Choose a unique prefix for the
+            diagnostic names to prevent output conflicts, because multiple populations are
+            possible. */
+        void extraDiagnostics(GasDiagnostics& gd, const std::string& prefix) const;
 
     private:
         // pointers to constant data


### PR DESCRIPTION
This branch has deviated a bit from the original purpose, which was to stop certain crashes relating to NaN situations. But I need to get these changes in. Some of them are important to make my newest SKIRT version work with RADAGAST.

API change: 
- Serialize and deserialize function makes it easy to store gas states in SKIRT.
- Sanity check when input quantities are passed to an update call
- SI option for the main API functions

Misc:
- Enable writing out some grain temperatures
 
